### PR TITLE
Treat Fixed type as in Avro.NET (as byte[]) and print CSV accordingly

### DIFF
--- a/LinuxPackage.nuspec
+++ b/LinuxPackage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json_linux</id>
-    <version>0.1.7</version>
+    <version>0.1.11</version>
     <authors>Michael Spector</authors>
     <owners>Michael Spector</owners>
     <license type="expression">MIT</license>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json</id>
-    <version>0.1.10</version>
+    <version>0.1.11</version>
     <authors>Michael Spector</authors>
     <owners>Michael Spector</owners>
     <license type="expression">MIT</license>

--- a/src/avro2json.c
+++ b/src/avro2json.c
@@ -561,6 +561,25 @@ static int write_escaped_str_to_csv(FILE *dest, const char *str, size_t size) {
   return 0;
 }
 
+static int write_byte_array_to_csv(FILE *dest, const char *str, size_t size) {
+  if (fprintf(dest, "\"[") < 0) {
+    return ferror(dest);
+  }
+  for (int i = 0; i < size; ++i) {
+    fprintf(dest, "%d", (unsigned char)str[i]);
+
+    if(i != size -1){
+      if (fputc(',', dest) < 0) {
+        return ferror(dest);
+      }
+    }
+  }
+  if (fprintf(dest, "]\"") < 0) {
+    return ferror(dest);
+  }
+  return 0;
+}
+
 static int dump_to_csv(const char *buffer, size_t size, void *data) {
   return write_escape_quotes((FILE *)data, buffer, size);
 }
@@ -598,7 +617,7 @@ static int avro_bytes_value_to_csv(FILE *dest, const avro_value_t *value,
     return 0;
   }
 
-  return write_escaped_str_to_csv(dest, (const char *)bytes, size);
+  return write_byte_array_to_csv(dest, (const char *)bytes, size);
 }
 
 static int avro_value_to_csv(FILE *dest, const avro_value_t *value,


### PR DESCRIPTION
For example, print 16-bytes fixed value as byte[] like this: "[227,131,34,92,28,91,65,72,134,138,9,133,51,45,104,52]"