### PR TITLE
Output telemetry if 'bytes' or 'fixed' are encountered and displayed as a byte array

### DIFF
--- a/LinuxPackage.nuspec
+++ b/LinuxPackage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json_linux</id>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
     <authors>Michael Spector</authors>
     <owners>Michael Spector</owners>
     <license type="expression">MIT</license>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json</id>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
     <authors>Michael Spector</authors>
     <owners>Michael Spector</owners>
     <license type="expression">MIT</license>

--- a/src/avro2json.c
+++ b/src/avro2json.c
@@ -113,6 +113,11 @@ int avro_byte_array_to_json_t(json_t **json, const unsigned char *bytes, size_t 
     return ENOMEM;
   }
 
+  static int printedByteArrayTelemetry = 0;
+  if(!printedByteArrayTelemetry++) {
+    fprintf(stderr, "Byte array detected\n", avro_strerror());
+  }
+
   for (size_t i = 0; i < element_count; i++) {
     if ((rval = json_array_append_new(result, json_integer((unsigned char)bytes[i]))) != 0) {
       avro_set_error("Cannot append element to array");
@@ -536,6 +541,10 @@ static int write_escaped_str_to_csv(FILE *dest, const char *str, size_t size) {
 }
 
 static int write_byte_array_to_csv(FILE *dest, const char *bytes, size_t size) {
+  static int printedByteArrayTelemetry = 0;
+  if(!printedByteArrayTelemetry++) {
+    fprintf(stderr, "Byte array detected\n", avro_strerror());
+  }
   CHECKED_PRINT(dest, "\"[");
   for (int i = 0; i < size; ++i) {
     CHECKED_PRINTF(dest, "%d", (unsigned char)bytes[i]);


### PR DESCRIPTION
Output telemetry if 'bytes' or 'fixed' are encountered and displayed as a byte array