### PR TITLE
Set stdout to binary mode to prevent LF->CRLF conversion on Windows

### DIFF
--- a/LinuxPackage.nuspec
+++ b/LinuxPackage.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json_linux</id>
-    <version>0.1.15</version>
-    <authors>Michael Spector</authors>
-    <owners>Michael Spector</owners>
+    <version>0.1.16</version>
+    <authors>Michael Spector, Igor Borodin</authors>
+    <owners>Michael Spector, Igor Borodin</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/azure-kusto-avro-conv</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Avro to JSON converter tool.</description>
-    <releaseNotes>Add an option for emitting CSV</releaseNotes>
+    <releaseNotes>Set stdout to binary mode to preserve line endings</releaseNotes>
     <copyright>Copyright 2020</copyright>
     <tags>utility avro json parsing</tags>
     <dependencies>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>avro2json</id>
-    <version>0.1.15</version>
-    <authors>Michael Spector</authors>
-    <owners>Michael Spector</owners>
+    <version>0.1.16</version>
+    <authors>Michael Spector, Igor Borodin</authors>
+    <owners>Michael Spector, Igor Borodin</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/azure-kusto-avro-conv</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Avro to JSON converter tool.</description>
-    <releaseNotes>Using jemalloc for Windows</releaseNotes>
+    <releaseNotes>Set stdout to binary mode to preserve line endings</releaseNotes>
     <copyright>Copyright 2020</copyright>
     <tags>utility avro json parsing</tags>
     <dependencies>

--- a/src/avro2json.c
+++ b/src/avro2json.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <io.h>
 #include <avro.h>
 #include <avro/schema.h>
 #include <errno.h>
@@ -1083,7 +1085,17 @@ custom_jemalloc_allocator(void *ud, void *ptr, size_t osize, size_t nsize)
 }
 #endif
 
+// Define _O_BINARY if it's not already defined
+#ifndef _O_BINARY
+#define _O_BINARY 0x8000
+#endif
+
 int main(int argc, char **argv) {
+
+#if defined(_WIN32)
+  // Set stdout to binary mode to preserve line endings
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
 
 #if defined(_WIN32)
 /* Currently provided only for Windows, since it was tested only on Windows. */

--- a/src/avro2json.c
+++ b/src/avro2json.c
@@ -1,11 +1,11 @@
-#include <stdio.h>
-#include <io.h>
 #include <avro.h>
 #include <avro/schema.h>
 #include <errno.h>
 #include <jansson.h>
 #include <stdlib.h>
 #if defined(_WIN32)
+#include <stdio.h>
+#include <io.h>
 #include <jemalloc.h>
 #endif
 #include <string.h>


### PR DESCRIPTION
Set stdout to binary mode to prevent newline characters (LF) being automatically converted to the CRLF on Windows
Promote Nuget to 0.1.16